### PR TITLE
fix: changed game_teams_dummy.csv file to match the games_dummy.csv

### DIFF
--- a/data/game_teams_dummy.csv
+++ b/data/game_teams_dummy.csv
@@ -8,3 +8,12 @@ game_id,team_id,HoA,result,settled_in,head_coach,goals,shots,tackles,pim,powerPl
 2012030224,6,away,WIN,OT,Claude Julien,3,10,24,8,4,2,53.7,8,6
 2012030224,3,home,LOSS,OT,John Tortorella,2,8,40,8,4,1,46.3,9,7
 2012030225,3,away,LOSS,REG,John Tortorella,1,7,25,13,2,1,50.9,5,3
+2012030225,6,home,WIN,REG,Claude Julien,3,8,35,11,3,1,49.1,12,9
+2012030311,6,away,WIN,REG,Claude Julien,3,7,19,17,4,0,66.7,1,5
+2012030311,5,home,LOSS,REG,Dan Bylsma,0,7,34,28,4,0,33.3,8,9
+2012030312,6,away,WIN,REG,Claude Julien,4,7,19,6,1,0,50.9,2,5
+2012030312,5,home,LOSS,REG,Dan Bylsma,1,6,37,4,2,0,49.1,12,5
+2012030313,5,away,LOSS,OT,Dan Bylsma,1,13,46,16,6,0,57.3,8,10
+2012030313,6,home,WIN,OT,Claude Julien,2,10,34,18,5,0,42.7,10,13
+2012030314,5,away,LOSS,REG,Dan Bylsma,0,6,33,8,3,0,47.5,8,1
+2012030314,6,home,WIN,REG,Claude Julien,1,6,25,8,3,0,52.5,11,5


### PR DESCRIPTION
I changed the game_teams_dummy.csv file to detail the same games as the games_dummy.csv file.

Since game_teams.csv lists each game twice (one entry for each team playing), the number of lines (excluding headers) is twice as long as the games.csv