### PR TITLE
Count of teams

### DIFF
--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -41,5 +41,8 @@ class StatTracker
     (home_wins.to_f / total_games).round(2)
   end
 
+  def count_of_teams
+    @teams[:team_id].uniq.count
+  end
 
 end

--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -41,4 +41,5 @@ class StatTracker
     (home_wins.to_f / total_games).round(2)
   end
 
+
 end

--- a/spec/stat_tracker_spec.rb
+++ b/spec/stat_tracker_spec.rb
@@ -17,29 +17,24 @@ RSpec.describe StatTracker do
     end
 
     it 'exists' do
-
       expect(@stat_tracker).to be_an_instance_of(StatTracker)
     end
 
     it 'has data' do
-
       expect(@stat_tracker.games).to be_an_instance_of(CSV::Table)
       expect(@stat_tracker.teams).to be_an_instance_of(CSV::Table)
       expect(@stat_tracker.game_teams).to be_an_instance_of(CSV::Table)
     end
 
     it 'has a total score' do
-
       expect(@stat_tracker.total_scores_per_game).to eq(34)
     end
 
     it 'has a lowest total score' do
-
       expect(@stat_tracker.lowest_total_score).to eq(1)
     end
 
     it 'show highest_total_score' do
-     
      expect(@stat_tracker.highest_total_score).to eq(5)
     end
 
@@ -49,6 +44,10 @@ RSpec.describe StatTracker do
 
     it 'shows the percentage_home_wins' do
       expect(@stat_tracker.percentage_home_wins).to eq(0.56)
+    end
+
+    it 'can count the total teams' do
+      expect(stat_tracker.count_of_teams).to eq(9)
     end
 
   end

--- a/spec/stat_tracker_spec.rb
+++ b/spec/stat_tracker_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe StatTracker do
     end
 
     it 'can count the total teams' do
-      expect(stat_tracker.count_of_teams).to eq(9)
+      expect(@stat_tracker.count_of_teams).to eq(3)
     end
 
   end


### PR DESCRIPTION
League Stats: count_of_teams method working. I used .uniq to make sure we dont duplicate team_id's once we are using the full files. Right now the dummy file only has 3 teams in it and they are all different from each other. 