### PR TITLE
Feat league helper method

### DIFF
--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -67,4 +67,31 @@ class StatTracker
   def count_of_teams
     @teams[:team_id].uniq.count
   end
+
+  def teams_and_goals #=> League Stats Helper Method
+    teams_and_goals_hash = {}
+    @teams.each do |team|
+      teams_and_goals_hash[team[:team_id]] = {
+        team_name: team[:teamname],
+        total_goals: 0,
+        total_games: 0,
+        total_home_goals: 0,
+        total_away_goals: 0,
+        total_home_games: 0,
+        total_away_games: 0
+      }
+    end
+    @game_teams.each do |game_team|
+      teams_and_goals_hash[game_team[:team_id]][:total_goals] += game_team[:goals]
+      teams_and_goals_hash[game_team[:team_id]][:total_games] += 1
+      if game_team[:hoa] == 'home'
+        teams_and_goals_hash[game_team[:team_id]][:total_home_goals] += game_team[:goals] 
+        teams_and_goals_hash[game_team[:team_id]][:total_home_games] += 1
+      else
+        teams_and_goals_hash[game_team[:team_id]][:total_away_goals] += game_team[:goals]
+        teams_and_goals_hash[game_team[:team_id]][:total_away_games] += 1
+      end
+    end
+    teams_and_goals_hash
+  end
 end

--- a/spec/stat_tracker_spec.rb
+++ b/spec/stat_tracker_spec.rb
@@ -52,6 +52,10 @@ RSpec.describe StatTracker do
     it 'shows the percentage_home_wins' do
       expect(@stat_tracker.percentage_home_wins).to eq(0.56)
     end
+    
+    it 'can return the team with the worst offense' do
+      expect(@stat_tracker.worst_offense).to eq("Sporting Kansas City")
+    end
 
     it 'can calculate percentage visitor wins' do
       expect(@stat_tracker.percentage_visitor_wins).to eq(0.44)

--- a/spec/stat_tracker_spec.rb
+++ b/spec/stat_tracker_spec.rb
@@ -52,10 +52,6 @@ RSpec.describe StatTracker do
     it 'shows the percentage_home_wins' do
       expect(@stat_tracker.percentage_home_wins).to eq(0.56)
     end
-    
-    it 'can return the team with the worst offense' do
-      expect(@stat_tracker.worst_offense).to eq("Sporting Kansas City")
-    end
 
     it 'can calculate percentage visitor wins' do
       expect(@stat_tracker.percentage_visitor_wins).to eq(0.44)
@@ -68,6 +64,11 @@ RSpec.describe StatTracker do
 
     it 'can count the total teams' do
       expect(@stat_tracker.count_of_teams).to eq(3)
+    end
+
+    it 'can return a hash of team and goal data' do
+      expect(@stat_tracker.teams_and_goals).to be_an(Hash)
+      expect(@stat_tracker.teams_and_goals[3][:total_goals]).to eq(8)
     end
   end
 end


### PR DESCRIPTION
creates a method that returns goal information for individual teams in a hash.
this hash can be used to easily implement other methods in League Stats