### PR TITLE
fixed best/worst offense methods to convert to float

### DIFF
--- a/lib/league_stats.rb
+++ b/lib/league_stats.rb
@@ -1,11 +1,11 @@
 module LeagueStats
 
   def worst_offense
-    @teams.values.min_by{ |team| team.total_overall_goals / team.games_participated_in.length }.team_name
+    @teams.values.min_by{ |team| team.total_overall_goals.to_f / team.games_participated_in.length }.team_name
   end
 
   def best_offense
-    @teams.values.max_by{ |team| team.total_overall_goals / team.games_participated_in.length }.team_name
+    @teams.values.max_by{ |team| team.total_overall_goals.to_f / team.games_participated_in.length }.team_name
   end
 
   def highest_scoring_home_team


### PR DESCRIPTION
after running the spec harness realized that these weren't working completely accurately because it was doing integer division